### PR TITLE
Remove exokit model that is no longer available.

### DIFF
--- a/block.scn
+++ b/block.scn
@@ -26,21 +26,6 @@
     },
     {
       "position": [
-        4,
-        0,
-        1
-      ],
-      "quaternion": [
-        0,
-        0.7071067811865475,
-        0,
-        0.7071067811865475
-      ],
-      "start_url": "https://avatar-models.exokit.org/model49.vrm",
-      "dynamic": true
-    },
-    {
-      "position": [
         0,
         0,
         0


### PR DESCRIPTION
The inclusion of this exokit model throws an error and prevents the scene from loading.

![image](https://user-images.githubusercontent.com/7455448/214959139-2f25af7c-1339-4dcf-bb06-dae93ec88ef8.png)
